### PR TITLE
fix: arrow keys browsed backwards in tt watch — read stdin raw (v0.5.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trigger-tree",
   "displayName": "trigger-tree",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Documentation-discovery telemetry: hooks log every doc read and skill use, live pulse dashboard (/tt watch), heat/cold maps with router-gap detection (/tt insights), evidence-backed fixes (/tt suggestions). macOS/Linux/Windows.",
   "author": {
     "name": "Hedde van der Heide"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.5.3 — 2026-07-17
+
+- **Fix: both arrow keys browsed backwards.** The key loop mixed `select()` on
+  the raw fd with buffered `sys.stdin.read()`: the buffered read slurped the
+  whole escape sequence, the follow-up `select()` saw an empty fd, and the
+  leftover `[` replayed on the *next* keypress — so ← and → both acted as
+  "prev", one press late. Keys are now read raw via `os.read()` (`read_key()`),
+  with a pipe-based regression test.
+
 ## 0.5.2 — 2026-07-17
 
 - **Arrow keys** now browse prompts too (←/→ on macOS/Linux escape sequences and

--- a/scripts/tt-watch.py
+++ b/scripts/tt-watch.py
@@ -371,6 +371,20 @@ def normalize_windows(code):
     return {"K": "[", "M": "]"}.get(code)
 
 
+def read_key(fd):
+    """Read one keypress from a raw fd, arrow escapes normalized to [ / ].
+
+    Must use os.read, never sys.stdin: the buffered reader slurps the whole
+    escape sequence off the fd in one read(1), the follow-up select() then sees
+    an empty fd, and the leftover "[" is replayed on the *next* keypress — so
+    every arrow key acted as "prev" one press late.
+    """
+    ch = os.read(fd, 1).decode(errors="replace")
+    if ch == "\x1b" and select.select([fd], [], [], 0.02)[0]:
+        ch = normalize_escape(os.read(fd, 2).decode(errors="replace")) or ""
+    return ch
+
+
 def handle_key(app, ch):
     """Key dispatch for the interactive loop. Returns True when the watcher should quit."""
     if ch in ("q", "Q"):
@@ -447,9 +461,7 @@ def main():
                     if wch and handle_key(app, wch):
                         break
             elif use_termios and select.select([sys.stdin], [], [], 0)[0]:  # pragma: no cover
-                ch = sys.stdin.read(1)
-                if ch == "\x1b" and select.select([sys.stdin], [], [], 0.02)[0]:
-                    ch = normalize_escape(sys.stdin.read(2)) or ""
+                ch = read_key(sys.stdin.fileno())
                 if ch and handle_key(app, ch):
                     break
             if args.demo and now >= next_evt:

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,7 +1,9 @@
 import json
+import os
 import sys
 import time
 
+import pytest
 from conftest import FIXTURE, load_script
 
 
@@ -181,6 +183,21 @@ def test_arrow_key_normalizers():
     assert mod.normalize_escape("[A") is None       # up/down: ignored
     assert mod.normalize_windows("K") == "[" and mod.normalize_windows("M") == "]"
     assert mod.normalize_windows("H") is None
+
+
+def test_read_key_consumes_full_escape_sequence():
+    # Regression: buffered sys.stdin.read(1) slurped the whole escape sequence,
+    # leaving a stray "[" that made every arrow key act as "prev" one press late.
+    if os.name == "nt":
+        pytest.skip("read_key is POSIX-only (select on a pipe fd)")
+    mod = load_script("tt-watch.py", FIXTURE)
+    r, w = os.pipe()
+    try:
+        os.write(w, b"\x1b[C\x1b[D\x1b[Cq")  # right, left, right, quit — back to back
+        assert [mod.read_key(r) for _ in range(4)] == ["]", "[", "]", "q"]
+    finally:
+        os.close(r)
+        os.close(w)
 
 
 def test_handle_key_dispatch():


### PR DESCRIPTION
## Symptoom

Zowel ← als → in `tt watch` bladerde **terug** door de prompts; je kwam nooit meer vooruit of terug naar de live view.

## Oorzaak

De key-lus combineerde `select()` op de raw file descriptor met het **gebufferde** `sys.stdin.read(1)`. Bij een pijltjestoets (`\x1b[C` / `\x1b[D`) slurpte de buffered read alle drie de bytes in Python's interne buffer en gaf alleen `\x1b` terug. De vervolg-`select()` zag een lege fd → toets genegeerd, en de achtergebleven `[` + letter bleven in de buffer hangen. Bij de **volgende** toetsaanslag kwam eerst die oude `[` eruit — en `[` betekent `select_prev()`. Omdat beide pijltjessequenties met `[` beginnen, deed elke pijl daarna "vorige prompt", één druk te laat.

## Fix

- Nieuwe `read_key(fd)`-helper die raw leest met `os.read()` — de hele escapesequentie wordt in één keypress-afhandeling geconsumeerd.
- Regressietest die via een `os.pipe` rechts/links/rechts/quit achter elkaar voert en de juiste key-reeks verwacht (skip op Windows; dat pad gebruikt `msvcrt` en had de bug niet).
- Changelog + versiebump naar 0.5.3.

## Verificatie

- `pytest tests -q`: 56 passed.
- E2E via een echte pty (`--demo`): ←← → browsen, →→ → terug naar live. Dezelfde check tegen `main` faalt precies zoals gemeld (blijft in browsing hangen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)