### PR TITLE
test: freeze doctor liveness clock

### DIFF
--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -17,9 +17,10 @@ def wire_project(project, events=True):
         )
 
 
-def test_doctor_all_checks_pass(tmp_path, capsys):
+def test_doctor_all_checks_pass(tmp_path, monkeypatch, capsys):
     wire_project(tmp_path)
     mod = load_script("tt-doctor.py", tmp_path)
+    monkeypatch.setattr(mod.time, "time", lambda: 1_784_282_400)
     assert mod.main() == 0
     out = capsys.readouterr().out
     assert out.count("✓") == 9


### PR DESCRIPTION
Fixes the time-dependent doctor test that turned stale after seven days and made every PR CI matrix fail.\n\nValidated locally: 309 passed, 1 skipped; 100% coverage; Black, Ruff, shellcheck, plugin validation, install smoke, release-integrity docs check, and trigger-tree gate all pass.